### PR TITLE
Enable rustls for HTTP/2 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ cacache = "11.6.0"
 futures = "0.3.28"
 libdeflater = "0.14.0"
 miette = "5.9.0"
-reqwest = "0.11.18"
+reqwest = { version = "0.11.18", default-features = false, features = ["rustls-tls"] }
 serde_json = "1.0.96"
 ssri = "9.0.0"
 tar = "0.4.38"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,15 @@ use std::{
     collections::HashMap,
     io::{Cursor, Read, Write},
     path::PathBuf,
+    sync::OnceLock,
 };
 use ssri::Integrity;
 use miette::{IntoDiagnostic};
 use sanitize_filename::sanitize;
 
 const STORE_DIR: &str = "pnpm-store";
+
+static CLIENT: OnceLock<Client> = OnceLock::new();
 
 #[macro_use]
 extern crate napi_derive;
@@ -27,7 +30,7 @@ pub async fn fetch_tarball(url: String) -> HashMap<String, String> {
 }
 
 async fn _fetch_tarball(url: &str) -> Result<bytes::Bytes, Box<dyn std::error::Error>> {
-    let client = Client::new();
+    let client = CLIENT.get_or_init(Client::new);
     let res = client.get(url)
         .send()
         .await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub async fn fetch_tarball(url: String) -> HashMap<String, String> {
 }
 
 async fn _fetch_tarball(url: &str) -> Result<bytes::Bytes, Box<dyn std::error::Error>> {
-    let client = CLIENT.get_or_init(Client::new);
+    let client = CLIENT.get_or_init(|| Client::builder().use_rustls_tls().build().unwrap());
     let res = client.get(url)
         .send()
         .await?;


### PR DESCRIPTION
Stacked on #1 to avoid a merge conflict, and because the benefits of HTTP/2 are only significant in the presence of connection pooling.